### PR TITLE
Change the layout of sponsors on mobile

### DIFF
--- a/templates/contents.html
+++ b/templates/contents.html
@@ -264,7 +264,7 @@
         </div>
 
         {% for id, item in bag('sponsors').items() %}
-            <div class="medium-6 small-6 column sponsor">
+            <div class="medium-6 small-12 column sponsor">
                 <a href="{{ item.link }}" target="_blank">
                     <img src="{{ item.image|asseturl }}" alt="{{ item.name }}"/>
                 </a>


### PR DESCRIPTION
Because currently it looks weird on mobile with two narrow blocks of text side by side

![image](https://cloud.githubusercontent.com/assets/5232693/24530422/1804aa24-15b2-11e7-9198-4341c740fd51.png)
